### PR TITLE
style: make tablets use mobile styling

### DIFF
--- a/src/components/base/DashboardCard.vue
+++ b/src/components/base/DashboardCard.vue
@@ -51,25 +51,25 @@ withDefaults(defineProps<Props>(), {
 }
 .is-one-third {
   grid-column-start: span 2;
-  @include mobile {
+  @include touch {
     grid-column-start: span 1;
   }
 }
 .is-half {
   grid-column-start: span 3;
-  @include mobile {
+  @include touch {
     grid-column-start: span 1;
   }
 }
 .is-full {
   grid-column-start: span 6;
-  @include mobile {
+  @include touch {
     grid-column-start: span 1;
   }
 }
 .is-two-thirds {
   grid-column-start: span 4;
-  @include mobile {
+  @include touch {
     grid-column-start: span 1;
   }
 }

--- a/src/components/base/SideBar.vue
+++ b/src/components/base/SideBar.vue
@@ -6,7 +6,7 @@
         <i v-else class="fas fa-bars" />
       </button>
     </div>
-    <div class="sidebar-body" :class="{ 'is-hidden-mobile': collapsed }">
+    <div class="sidebar-body" :class="{ 'is-hidden-touch': collapsed }">
       <p v-if="!collapsed" class="menu-label">Narragansett Bay Data Explorer</p>
       <p v-else class="menu-label">
         <abbr title="Narragansett Bay Data Explorer">NBDE</abbr>

--- a/src/layouts/dashboard.vue
+++ b/src/layouts/dashboard.vue
@@ -41,7 +41,7 @@ const collapsed = ref(false);
   overflow: hidden;
   background-color: whitesmoke;
   min-height: 90vh;
-  @include mobile {
+  @include touch {
     min-height: auto;
   }
 }
@@ -53,7 +53,7 @@ main {
   display: grid;
   grid-template-columns: 2fr 10fr;
   grid-template-areas: "sidebar main";
-  @include mobile {
+  @include touch {
     grid-template-columns: 100vw;
     grid-template-areas:
       "sidebar"
@@ -65,7 +65,7 @@ main {
   display: grid;
   grid-template-columns: 8ch auto;
   grid-template-areas: "sidebar main";
-  @include mobile {
+  @include touch {
     grid-template-columns: 100vw;
     grid-template-rows: auto auto;
     grid-template-areas:
@@ -89,7 +89,7 @@ main {
   justify-content: space-between;
   align-content: start;
   grid-auto-flow: row;
-  @include mobile {
+  @include touch {
     grid-template-columns: 100vw;
     column-gap: 0px;
     padding-left: 0px !important; // overrides @extend px-4


### PR DESCRIPTION
Tablets were using the desktop layout and it's just too squishy.  Switch tablets to using the mobile layout instead.