### PR TITLE
fix: error page stacking and general isolation of contexts

### DIFF
--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -19,6 +19,11 @@ $primary-color: $link;
   flex-direction: column;
 }
 
+// utility to isolate stacks
+.is-isolated {
+  isolation: isolate;
+}
+
 /* used by download form and explore form fields */
 .control-item {
   @extend .py-2;

--- a/src/components/base/DashboardCard.vue
+++ b/src/components/base/DashboardCard.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="dashboard-card" :class="['is-' + width, 'is-height-' + height]">
+  <div
+    class="dashboard-card is-isolated"
+    :class="['is-' + width, 'is-height-' + height]"
+  >
     <header class="dashboard-card-header">
       <h2 class="title">
         <slot name="title" />

--- a/src/components/base/ErrorPage.vue
+++ b/src/components/base/ErrorPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="error-container">
+  <main class="error-container is-isolated">
     <div class="error-content">
       <i class="fas fa-life-ring mr-2 has-text-danger" />
       <p>{{ message }}</p>
@@ -49,6 +49,7 @@ const goBack = () => {
   top: 0;
   left: 0;
   background: white;
+  z-index: 2;
 }
 .error-content {
   font-size: 3rem;

--- a/src/components/base/SuspenseComponent.vue
+++ b/src/components/base/SuspenseComponent.vue
@@ -1,5 +1,4 @@
 <template>
-  <ErrorPage v-if="errored" :message="errorMessage" @clear="errored = false" />
   <Suspense :key="$route.path">
     <slot />
 
@@ -7,6 +6,8 @@
       <LoadingSpinner :loading="true" />
     </template>
   </Suspense>
+
+  <ErrorPage v-if="errored" :message="errorMessage" @clear="errored = false" />
 </template>
 
 <script setup lang="ts">

--- a/src/layouts/dashboard.vue
+++ b/src/layouts/dashboard.vue
@@ -1,5 +1,8 @@
 <template>
-  <div :class="[collapsed ? 'dashboard-grid-collapsed' : 'dashboard-grid']">
+  <div
+    :class="[collapsed ? 'dashboard-grid-collapsed' : 'dashboard-grid']"
+    class="is-isolated"
+  >
     <aside class="sidebar">
       <SideBar @toggle="collapsed = !collapsed" />
     </aside>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="layout">
+  <div class="layout is-isolated">
     <a class="logo-container" href="https://ridatadiscovery.org">
       <span class="brand-title">Rhode Island Data Discovery Center</span>
       <BaseLogo />

--- a/src/views/datasets/index.vue
+++ b/src/views/datasets/index.vue
@@ -1,11 +1,11 @@
 <template>
-  <DashboardLayout>
-    <router-view v-slot="{ Component }">
-      <SuspenseComponent :key="$route.path">
+  <router-view v-slot="{ Component }">
+    <SuspenseComponent :key="$route.path">
+      <DashboardLayout>
         <component :is="Component"></component>
-      </SuspenseComponent>
-    </router-view>
-  </DashboardLayout>
+      </DashboardLayout>
+    </SuspenseComponent>
+  </router-view>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
* move the error page to after the suspense component so natural ordering rules do most of the work
* isolate the stacking contexts of the main sections of the app (added a utility styling class here)
* set the zindex of the error page to 2 to make sure it's on top of the footer