### PR TITLE
refactor: move buoy icon height/width to xml for safari compatibility

### DIFF
--- a/src/assets/illustrations/buoy-marker.svg
+++ b/src/assets/illustrations/buoy-marker.svg
@@ -1,6 +1,6 @@
 <svg version="1.1"
 	 id="buoy-icon" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg"
-	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 100 100"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 100 100" width="15px" height="15px"
 	 style="enable-background:new 0 0 100 100;" xml:space="preserve">
 <g transform="translate(0,-952.36217)">
 	<path d="M37.9,953.5v21.9l-2.2,0l-6.4,56.6h-5.7c0,7.6,2.6,13.1,6.7,16.8c0.4,0,0.9,0.1,1.4,0.1c3.8,0,6.1-1.5,6.1-1.5

--- a/src/components/buoy-telemetry/BuoyMap.vue
+++ b/src/components/buoy-telemetry/BuoyMap.vue
@@ -13,13 +13,7 @@
   <img
     ref="imageEl"
     :src="BuoyMarker"
-    style="
-      visibility: hidden;
-      height: 15px;
-      width: 15px;
-      position: absolute;
-      top: 0;
-    "
+    style="visibility: hidden; position: absolute; top: 0"
   />
 </template>
 


### PR DESCRIPTION
Safari wasn't showing buoy icons. The solution was to move the height and width to the svg xml source instead of declaring the size in the <img> tag on the map Vue.