### PR TITLE
fix: fix alignment on buoy labels

### DIFF
--- a/src/components/charts/BayMap.vue
+++ b/src/components/charts/BayMap.vue
@@ -42,7 +42,7 @@ const legendSpec = computed(() =>
     ? [
         {
           title: "Buoys",
-          orient: "bottom-left",
+          orient: "bottom",
           type: "symbol",
           symbolType: "circle",
           fill: "color",


### PR DESCRIPTION
I played around with different alignments for the labels and simply changing to `bottom` fixes the issue with labels not wrapping. It also moves the labels below the map instead of on top of the south coast. It seems to work well on all screen sizes.[https://github.com/ridatadiscoverycenter/buoy-viewer/issues/5](url)

<img width="900" alt="image" src="https://user-images.githubusercontent.com/24841909/173594503-c449e587-ab30-4ee9-81c5-1077ebcc4eac.png">
