### PR TITLE
fix: don't error on undefined windspeed

### DIFF
--- a/src/components/buoy-telemetry/BuoyMap.vue
+++ b/src/components/buoy-telemetry/BuoyMap.vue
@@ -213,10 +213,10 @@ const geoJSON = computed(() => {
               windSpeed:
                 annotatedWindSpeedms.value.find((w) => {
                   return w.station_name === station_name;
-                }).value / knotsPerMS,
+                })?.value / knotsPerMS,
               windDirection: annotatedWindDir.value.find((w) => {
                 return w.station_name === station_name;
-              }).value,
+              })?.value,
             },
           };
         },


### PR DESCRIPTION
# What changed

The time slider on the map was broken; moving it caused the entire page to display an error.

- Adds a `?` flag to the place that was causing the error.