### PR TITLE
fix: m/s to knots conversion

### DIFF
--- a/src/components/buoy-telemetry/BuoyMap.vue
+++ b/src/components/buoy-telemetry/BuoyMap.vue
@@ -218,7 +218,7 @@ const windspeedGeoJSON = computed(() => {
             windSpeed:
               annotatedWindSpeedms.value.find((w) => {
                 return w.station_name === station_name;
-              })?.value / KNOTS_PER_MS,
+              })?.value * KNOTS_PER_MS,
             windDirection: annotatedWindDir.value.find((w) => {
               return w.station_name === station_name;
             })?.value,


### PR DESCRIPTION
I believe the conversion from m/s to knots was incorrect, since it was dividing by the number of knots per m/s instead of multiplying.